### PR TITLE
Primitives

### DIFF
--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>com.pro-crafting.mc</groupId>
         <artifactId>WorldFuscator</artifactId>
@@ -21,6 +22,12 @@
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
             <version>${version.protocollib}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+            <version>8.2.2</version>
             <scope>provided</scope>
         </dependency>
 

--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>it.unimi.dsi</groupId>
             <artifactId>fastutil</artifactId>
-            <version>8.2.2</version>
+            <version>${version.fastutil}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/BlockTranslator.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/BlockTranslator.java
@@ -1,13 +1,13 @@
 package com.pro_crafting.mc.worldfuscator.engine;
 
 import com.pro_crafting.mc.worldfuscator.Configuration;
+import com.pro_crafting.mc.worldfuscator.engine.palette.GlobalPaletteAdapter;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
-import com.pro_crafting.mc.worldfuscator.engine.palette.GlobalPaletteAdapter;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 
 public class BlockTranslator {
@@ -16,8 +16,8 @@ public class BlockTranslator {
     private WorldFuscatorGuard guard;
 
     private Configuration configuration;
-    private List<Integer> hiddenGlobalPaletteIds = new ArrayList<>();
-    private Integer preferedObfuscationGlobalPaletteId;
+    private IntList hiddenGlobalPaletteIds = new IntArrayList();
+    private int preferedObfuscationGlobalPaletteId;
 
     public BlockTranslator() {
     }
@@ -35,7 +35,7 @@ public class BlockTranslator {
 
         // TODO: Use default block state instead of any
         // But in theory, the first block state should be the default state
-        preferedObfuscationGlobalPaletteId = globalPaletteAdapter.getAllStateIds(configuration.getPreferredObfuscationMaterial()).iterator().next();
+        preferedObfuscationGlobalPaletteId = globalPaletteAdapter.getAllStateIds(configuration.getPreferredObfuscationMaterial()).getInt(0);
         if (configuration.isDebugEnabled()) {
             System.out.println("Chosen Global Palette Id: " + preferedObfuscationGlobalPaletteId + " as prefered obfuscation material");
         }
@@ -63,11 +63,11 @@ public class BlockTranslator {
         updatePaletteIds();
     }
 
-    public List<Integer> getHiddenGlobalPaletteIds() {
+    public IntList getHiddenGlobalPaletteIds() {
         return hiddenGlobalPaletteIds;
     }
 
-    public Integer getPreferedObfuscationGlobalPaletteId() {
+    public int getPreferedObfuscationGlobalPaletteId() {
         return preferedObfuscationGlobalPaletteId;
     }
 

--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/MapPacketChunkletProcessor.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/MapPacketChunkletProcessor.java
@@ -6,12 +6,12 @@ import com.comphenix.protocol.wrappers.nbt.NbtFactory;
 import com.pro_crafting.mc.worldfuscator.VarIntUtil;
 import com.pro_crafting.mc.worldfuscator.engine.palette.Palette;
 import com.pro_crafting.mc.worldfuscator.engine.palette.PaletteFactory;
+import it.unimi.dsi.fastutil.ints.IntList;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 
 import java.nio.ByteBuffer;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
@@ -100,7 +100,7 @@ public class MapPacketChunkletProcessor implements ChunkPacketProcessor.Chunklet
         }
 
         // Translate the hidden states from global ids to palette ids
-        Collection<Integer> hiddenPaletteIds = palette.translate(this.blockTranslator.getHiddenGlobalPaletteIds());
+        IntList hiddenPaletteIds = palette.translate(this.blockTranslator.getHiddenGlobalPaletteIds());
 
         long[] blockIndizes = new long[dataLength];
         buffer.asLongBuffer().get(blockIndizes);

--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/palette/DirectPalette.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/palette/DirectPalette.java
@@ -1,6 +1,7 @@
 package com.pro_crafting.mc.worldfuscator.engine.palette;
 
-import java.util.Collection;
+
+import it.unimi.dsi.fastutil.ints.IntList;
 
 /**
  * The direct palette is a 1:1 mapping to the global palette
@@ -13,28 +14,28 @@ public class DirectPalette implements Palette {
      * @return No further description provided
      */
     @Override
-    public boolean containsAny(Collection<Integer> materials) {
+    public boolean containsAny(IntList materials) {
         return true;
     }
 
     @Override
-    public boolean contains(Integer globalPaletteId) {
+    public boolean contains(int globalPaletteId) {
         return true;
     }
 
     @Override
-    public Integer searchAnyNonMatching(Collection<Integer> globalPaletteIds) {
+    public int searchAnyNonMatching(IntList globalPaletteIds) {
         // Should never be called anyways..
         return -1;
     }
 
     @Override
-    public Collection<Integer> translate(Collection<Integer> materials) {
+    public IntList translate(IntList materials) {
         return materials;
     }
 
     @Override
-    public Integer translate(Integer globalPaletteId) {
+    public int translate(int globalPaletteId) {
         return globalPaletteId;
     }
 }

--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/palette/IndirectPalette.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/palette/IndirectPalette.java
@@ -1,16 +1,15 @@
 package com.pro_crafting.mc.worldfuscator.engine.palette;
 
 import com.pro_crafting.mc.worldfuscator.VarIntUtil;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 public class IndirectPalette implements Palette {
-    private Map<Integer, Integer> globalPaletteIdToPaletteIndex = new HashMap<>();
+    private Int2IntMap globalPaletteIdToPaletteIndex = new Int2IntOpenHashMap();
 
     public IndirectPalette(ByteBuffer buffer) {
         int paletteLength = VarIntUtil.deserializeVarInt(buffer);
@@ -23,43 +22,47 @@ public class IndirectPalette implements Palette {
     }
 
     @Override
-    public boolean containsAny(Collection<Integer> globalPaletteIds) {
-        for (Integer paletteId : globalPaletteIds) {
-            if (globalPaletteIdToPaletteIndex.containsKey(paletteId)) {
+    public boolean containsAny(IntList globalPaletteIds) {
+        for (int i = 0; i < globalPaletteIds.size(); i++) {
+            if (globalPaletteIdToPaletteIndex.containsKey(globalPaletteIds.getInt(i))) {
                 return true;
             }
         }
+
         return false;
     }
 
     @Override
-    public boolean contains(Integer globalPaletteId) {
+    public boolean contains(int globalPaletteId) {
         return globalPaletteIdToPaletteIndex.containsKey(globalPaletteId);
     }
 
     @Override
-    public Integer searchAnyNonMatching(Collection<Integer> globalPaletteIds) {
-        for (Map.Entry<Integer, Integer> globalPaleteIdPaleteId : globalPaletteIdToPaletteIndex.entrySet()) {
-            if (!globalPaletteIds.contains(globalPaleteIdPaleteId.getKey())) {
-                return globalPaleteIdPaleteId.getValue();
+    public int searchAnyNonMatching(IntList globalPaletteIds) {
+        for (Int2IntMap.Entry next : globalPaletteIdToPaletteIndex.int2IntEntrySet()) {
+            if (!globalPaletteIds.contains(next.getIntKey())) {
+                return next.getIntValue();
             }
         }
         return -1;
     }
 
     @Override
-    public Collection<Integer> translate(Collection<Integer> globalPaletteIds) {
-        List<Integer> paletteIndizes = new ArrayList<>();
+    public IntList translate(IntList globalPaletteIds) {
 
-        for (Integer globalId : globalPaletteIds) {
-            paletteIndizes.add(globalPaletteIdToPaletteIndex.get(globalId));
+        IntList paletteIndizes = new IntArrayList();
+
+        for (int i = 0; i < globalPaletteIds.size(); i++) {
+            if (globalPaletteIdToPaletteIndex.containsKey(globalPaletteIds.getInt(i))) {
+                paletteIndizes.add(globalPaletteIdToPaletteIndex.get(globalPaletteIds.getInt(i)));
+            }
         }
 
         return paletteIndizes;
     }
 
     @Override
-    public Integer translate(Integer globalPaletteId) {
+    public int translate(int globalPaletteId) {
         return globalPaletteIdToPaletteIndex.get(globalPaletteId);
     }
 }

--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/palette/Palette.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/palette/Palette.java
@@ -1,6 +1,6 @@
 package com.pro_crafting.mc.worldfuscator.engine.palette;
 
-import java.util.Collection;
+import it.unimi.dsi.fastutil.ints.IntList;
 
 public interface Palette {
     /**
@@ -9,7 +9,7 @@ public interface Palette {
      * @param globalPaletteIds global palette ids to search for
      * @return true if any of the global palette ids found in palette, otherwise false
      */
-    boolean containsAny(Collection<Integer> globalPaletteIds);
+    boolean containsAny(IntList globalPaletteIds);
 
     /**
      * Checks if this palette contains the specified global palette block state identifier
@@ -17,7 +17,7 @@ public interface Palette {
      * @param globalPaletteId No further description provided
      * @return true if this palette contains the specified global palette block state identifier, otherwise false
      */
-    boolean contains(Integer globalPaletteId);
+    boolean contains(int globalPaletteId);
 
     /**
      * Searches for any palette index whose global palette id does not exists in the given list of ids
@@ -25,7 +25,7 @@ public interface Palette {
      * @param globalPaletteIds No further description provided
      * @return No further description provided
      */
-    Integer searchAnyNonMatching(Collection<Integer> globalPaletteIds);
+    int searchAnyNonMatching(IntList globalPaletteIds);
 
     /**
      * Translates global palette ids to its corresponding palette index. The palette index is always used in the chunk packet.
@@ -33,7 +33,7 @@ public interface Palette {
      * @param globalPaletteIds global palette ids to translate
      * @return Collection of palette indexes
      */
-    Collection<Integer> translate(Collection<Integer> globalPaletteIds);
+    IntList translate(IntList globalPaletteIds);
 
     /**
      * Translate a global palette id to the corresponding pallte index. The palette index is always used in the chunk packet.
@@ -41,5 +41,5 @@ public interface Palette {
      * @param globalPaletteId No further description provided
      * @return palette index
      */
-    Integer translate(Integer globalPaletteId);
+    int translate(int globalPaletteId);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <version.mockito>2.2.15</version.mockito>
         <version.commons-io>2.5</version.commons-io>
         <version.spigot-api>1.14.4-R0.1-SNAPSHOT</version.spigot-api>
-
+        <version.fastutil>8.2.2</version.fastutil>
         <!-- Plugin Versions -->
         <version.maven-shade-plugin>3.2.1</version.maven-shade-plugin>
         <version.sonar-maven-plugin>3.4.1.1168</version.sonar-maven-plugin>


### PR DESCRIPTION
Use primitive ints in all places we check for block states.
This significantly speeds up operations.

![image](https://user-images.githubusercontent.com/1223135/81409855-2735e780-9140-11ea-8cf9-14a0caea8c23.png)
