### PR TITLE
Use sets for for repeated material checks

### DIFF
--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/VarIntUtil.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/VarIntUtil.java
@@ -2,7 +2,7 @@ package com.pro_crafting.mc.worldfuscator;
 
 import java.nio.ByteBuffer;
 
-// Aus dem 1.9.1 MC Server (PacketSerializer)
+// taken from 1.9.1 mc server (PacketSerializer class)
 public class VarIntUtil {
 
     public static int deserializeVarInt(ByteBuffer buf) {

--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/BlockTranslator.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/BlockTranslator.java
@@ -2,8 +2,8 @@ package com.pro_crafting.mc.worldfuscator.engine;
 
 import com.pro_crafting.mc.worldfuscator.Configuration;
 import com.pro_crafting.mc.worldfuscator.engine.palette.GlobalPaletteAdapter;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -16,7 +16,7 @@ public class BlockTranslator {
     private WorldFuscatorGuard guard;
 
     private Configuration configuration;
-    private IntList hiddenGlobalPaletteIds = new IntArrayList();
+    private IntSet hiddenGlobalPaletteIds = new IntOpenHashSet();
     private int preferedObfuscationGlobalPaletteId;
 
     public BlockTranslator() {
@@ -63,7 +63,7 @@ public class BlockTranslator {
         updatePaletteIds();
     }
 
-    public IntList getHiddenGlobalPaletteIds() {
+    public IntSet getHiddenGlobalPaletteIds() {
         return hiddenGlobalPaletteIds;
     }
 

--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/palette/DirectPalette.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/palette/DirectPalette.java
@@ -1,7 +1,7 @@
 package com.pro_crafting.mc.worldfuscator.engine.palette;
 
 
-import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntSet;
 
 /**
  * The direct palette is a 1:1 mapping to the global palette
@@ -14,7 +14,7 @@ public class DirectPalette implements Palette {
      * @return No further description provided
      */
     @Override
-    public boolean containsAny(IntList materials) {
+    public boolean containsAny(IntSet materials) {
         return true;
     }
 
@@ -24,13 +24,13 @@ public class DirectPalette implements Palette {
     }
 
     @Override
-    public int searchAnyNonMatching(IntList globalPaletteIds) {
+    public int searchAnyNonMatching(IntSet globalPaletteIds) {
         // Should never be called anyways..
         return -1;
     }
 
     @Override
-    public IntList translate(IntList materials) {
+    public IntSet translate(IntSet materials) {
         return materials;
     }
 

--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/palette/IndirectPalette.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/palette/IndirectPalette.java
@@ -3,8 +3,8 @@ package com.pro_crafting.mc.worldfuscator.engine.palette;
 import com.pro_crafting.mc.worldfuscator.VarIntUtil;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -25,9 +25,9 @@ public class IndirectPalette implements Palette {
     }
 
     @Override
-    public boolean containsAny(IntList globalPaletteIds) {
-        for (int i = 0; i < globalPaletteIds.size(); i++) {
-            if (globalPaletteIdToPaletteIndex.containsKey(globalPaletteIds.getInt(i))) {
+    public boolean containsAny(IntSet globalPaletteIds) {
+        for (Int2IntMap.Entry next : globalPaletteIdToPaletteIndex.int2IntEntrySet()) {
+            if (globalPaletteIds.contains(next.getIntKey())) {
                 return true;
             }
         }
@@ -41,7 +41,7 @@ public class IndirectPalette implements Palette {
     }
 
     @Override
-    public int searchAnyNonMatching(IntList globalPaletteIds) {
+    public int searchAnyNonMatching(IntSet globalPaletteIds) {
         for (Int2IntMap.Entry next : globalPaletteIdToPaletteIndex.int2IntEntrySet()) {
             if (!globalPaletteIds.contains(next.getIntKey())) {
                 return next.getIntValue();
@@ -51,15 +51,15 @@ public class IndirectPalette implements Palette {
     }
 
     @Override
-    public IntList translate(IntList globalPaletteIds) {
+    public IntSet translate(IntSet globalPaletteIds) {
 
-        IntList paletteIndizes = new IntArrayList();
+        IntSet paletteIndizes = new IntOpenHashSet();
 
-        for (int i = 0; i < globalPaletteIds.size(); i++) {
-            if (globalPaletteIdToPaletteIndex.containsKey(globalPaletteIds.getInt(i))) {
-                paletteIndizes.add(globalPaletteIdToPaletteIndex.get(globalPaletteIds.getInt(i)));
+        globalPaletteIds.forEach((int value) -> {
+            if (globalPaletteIdToPaletteIndex.containsKey(value)) {
+                paletteIndizes.add(globalPaletteIdToPaletteIndex.get(value));
             }
-        }
+        });
 
         return paletteIndizes;
     }
@@ -69,7 +69,7 @@ public class IndirectPalette implements Palette {
         return globalPaletteIdToPaletteIndex.get(globalPaletteId);
     }
 
-    public void replace(IntList globalPaletteIds, Integer globalPaletteId) {
+    public void replace(IntSet globalPaletteIds, Integer globalPaletteId) {
         Integer paletteIndex = translate(globalPaletteId);
 
         if (paletteIndex == null) {

--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/palette/Palette.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/palette/Palette.java
@@ -1,6 +1,6 @@
 package com.pro_crafting.mc.worldfuscator.engine.palette;
 
-import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntSet;
 
 public interface Palette {
     /**
@@ -9,7 +9,7 @@ public interface Palette {
      * @param globalPaletteIds global palette ids to search for
      * @return true if any of the global palette ids found in palette, otherwise false
      */
-    boolean containsAny(IntList globalPaletteIds);
+    boolean containsAny(IntSet globalPaletteIds);
 
     /**
      * Checks if this palette contains the specified global palette block state identifier
@@ -25,7 +25,7 @@ public interface Palette {
      * @param globalPaletteIds No further description provided
      * @return No further description provided
      */
-    int searchAnyNonMatching(IntList globalPaletteIds);
+    int searchAnyNonMatching(IntSet globalPaletteIds);
 
     /**
      * Translates global palette ids to its corresponding palette index. The palette index is always used in the chunk packet.
@@ -33,7 +33,7 @@ public interface Palette {
      * @param globalPaletteIds global palette ids to translate
      * @return Collection of palette indexes
      */
-    IntList translate(IntList globalPaletteIds);
+    IntSet translate(IntSet globalPaletteIds);
 
     /**
      * Translate a global palette id to the corresponding pallte index. The palette index is always used in the chunk packet.

--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/processor/ChunkAndBlockChunkletProcessor.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/processor/ChunkAndBlockChunkletProcessor.java
@@ -8,7 +8,7 @@ import com.pro_crafting.mc.worldfuscator.engine.BlockTranslator;
 import com.pro_crafting.mc.worldfuscator.engine.VariableValueArray;
 import com.pro_crafting.mc.worldfuscator.engine.palette.Palette;
 import com.pro_crafting.mc.worldfuscator.engine.palette.PaletteFactory;
-import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -109,7 +109,7 @@ public class ChunkAndBlockChunkletProcessor implements ChunkletProcessor {
         }
 
         // Translate the hidden states from global ids to palette ids
-        IntList hiddenPaletteIds = palette.translate(this.blockTranslator.getHiddenGlobalPaletteIds());
+        IntSet hiddenPaletteIds = palette.translate(this.blockTranslator.getHiddenGlobalPaletteIds());
 
         long[] blockIndizes = new long[dataLength];
         buffer.asLongBuffer().get(blockIndizes);


### PR DESCRIPTION
This removes a ton of O(n), and replaces them with near constant time lookups
In Practice, this saves a ton of processing time, when running completly on main thread.

![image](https://user-images.githubusercontent.com/1223135/81479777-c4b71700-9225-11ea-82e4-22ba05ae31fc.png)

