### PR TITLE
remove option of fuscation on worker threads

### DIFF
--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/Configuration.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/Configuration.java
@@ -14,13 +14,10 @@ public class Configuration {
     private List<String> hiddenMaterialFilters;
     private String preferredObfuscationFilter;
     private Set<String> hiddenBlockEntityIds;
-    private int asyncWorkerCount;
 
     public Configuration(FileConfiguration configuration) {
         this.debugEnabled = configuration.getBoolean("debug.enabled", false);
         this.fuscationMode = FuscationMode.valueOf(configuration.getString("fuscation-mode", FuscationMode.CHUNK_AND_BLOCK.name()));
-
-        this.asyncWorkerCount = configuration.getInt("async.worker-count", 0);
 
         this.preferredObfuscationFilter = configuration.getString("preferred-obfuscation-filter", "minecraft:end_stone");
 
@@ -47,10 +44,6 @@ public class Configuration {
 
     public FuscationMode getFuscationMode() {
         return fuscationMode;
-    }
-
-    public int getAsyncWorkerCount() {
-        return asyncWorkerCount;
     }
 
     public List<String> getHiddenMaterialFilters() {

--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/WorldFuscatorEngine.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/WorldFuscatorEngine.java
@@ -59,7 +59,6 @@ public class WorldFuscatorEngine {
                 Server.BLOCK_BREAK) {
 
             public void onPacketSending(PacketEvent event) {
-//                System.out.println("SEND " + event.getPacketType().name());
                 Player player = event.getPlayer();
                 if (player.hasPermission("worldfuscator.bypass")) {
                     return;
@@ -81,11 +80,7 @@ public class WorldFuscatorEngine {
             }
         };
 
-        if (translator.getConfiguration().getAsyncWorkerCount() > 0 && processor.isThreadSafe()) {
-            ProtocolLibrary.getProtocolManager().getAsynchronousManager().registerAsyncHandler(listener).start(translator.getConfiguration().getAsyncWorkerCount());
-        } else {
-            ProtocolLibrary.getProtocolManager().addPacketListener(listener);
-        }
+        ProtocolLibrary.getProtocolManager().addPacketListener(listener);
     }
 
     private PacketContainer translateSingleBlock(PacketContainer packet, World world, Player player){

--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/guard/WorldFuscatorGuard.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/guard/WorldFuscatorGuard.java
@@ -4,13 +4,9 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 
 public interface WorldFuscatorGuard {
-    public default boolean hasAreaRights(Player player, int minX, int minY, int minZ, int maxX, int maxY, int maxZ,  World world) {
+    default boolean hasAreaRights(Player player, int minX, int minY, int minZ, int maxX, int maxY, int maxZ,  World world) {
         return false;
     }
 
-    public boolean hasRights(Player player, int x, int y, int z, World world);
-
-    public default boolean isThreadSafe() {
-        return true;
-    }
+    boolean hasRights(Player player, int x, int y, int z, World world);
 }

--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/processor/ChunkAndBlockChunkletProcessor.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/processor/ChunkAndBlockChunkletProcessor.java
@@ -82,12 +82,6 @@ public class ChunkAndBlockChunkletProcessor implements ChunkletProcessor {
         return true;
     }
 
-    @Override
-    public boolean isThreadSafe() {
-        // We do not access any unsafe api here, check if our guard is thread safe
-        return blockTranslator.getWorldFuscatorGuard().isThreadSafe();
-    }
-
     private boolean translateChunkData(Location origin, ByteBuffer buffer, Player player,
                                     int bitsPerBlock, Palette palette, int dataLength, int beforeData) {
         World world = origin.getWorld();

--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/processor/ChunkChunkletProcessor.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/processor/ChunkChunkletProcessor.java
@@ -96,9 +96,4 @@ public class ChunkChunkletProcessor implements ChunkletProcessor {
         // TODO: Fix this
         return false;
     }
-
-    @Override
-    public boolean isThreadSafe() {
-        return true;
-    }
 }

--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/processor/ChunkPaletteChunkletProcessor.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/processor/ChunkPaletteChunkletProcessor.java
@@ -63,9 +63,4 @@ public class ChunkPaletteChunkletProcessor implements ChunkletProcessor {
         // TODO: FIX THIS
         return false;
     }
-
-    @Override
-    public boolean isThreadSafe() {
-        return true;
-    }
 }

--- a/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/processor/ChunkletProcessor.java
+++ b/Core/src/main/java/com/pro_crafting/mc/worldfuscator/engine/processor/ChunkletProcessor.java
@@ -18,6 +18,4 @@ public interface ChunkletProcessor {
     public boolean processChunkletBlockData(Location origin, ByteBuffer buffer, Player player);
 
     public boolean processChunkletBlockEntities(World world, int chunkX, int chunkZ, List<NbtBase<?>> blockEntities, Player player);
-
-    public boolean isThreadSafe();
 }


### PR DESCRIPTION
This option always caused bugs, and was from a performance view not needed. Delegating to the worker threads was more costly then the fuscation itself.